### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default class MagicUrl {
       return
     }
     let [leaf] = this.quill.getLeaf(sel.index)
-    if (!leaf.text) {
+    if (!leaf.text || leaf.parent.domNode.localName === "a") {
       return
     }
     let urlMatch = leaf.text.match(this.options.urlRegularExpression)


### PR DESCRIPTION
This is a (suggested) fix for the [issue](https://github.com/visualjerk/quill-magic-url/issues/8) with editing links. Currently they break into multiple invalid URLs (if you add a space in them), this way you can type or paste a link and then edit it without changing the underlying URL.