### PR TITLE
Bugfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,9 @@ export default class MagicUrl {
     if (!urlMatch) {
       return
     }
-    let stepsBack = leaf.text.length - urlMatch.index
-    let index = sel.index - stepsBack
+    let leafIndex = this.quill.getIndex(leaf)
+    let index = leafIndex + urlMatch.index
+    
     this.textToUrl(index, urlMatch[0])
   }
   textToUrl (index, url) {


### PR DESCRIPTION
Fixes a bug that occurs when you try to type a URL between words (rather than the end of the content) - for example, if you have the following text:

"word1 word2"

Typing a URL between those (i.e. turning it into "word1 http://exampleurl.com word2") didn't really work. This change should take care of that.