### PR TITLE
Fix normalized url internal error by update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4897,9 +4897,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.1.0.tgz",
+      "integrity": "sha512-UxHuSWsSAmzSqN+DSjasaZWQ3QPtEisHdlr4y9MJ5zg0RcImv5fQt8QM0izJSCdsdmhJGK+ubcTpJXwVDmwSVQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "normalize-url": "^4.5.0",
+    "normalize-url": "^5.1.0",
     "quill-delta": "^3.6.2"
   }
 }


### PR DESCRIPTION
I have notice that sometimes the follow error happens:
![image](https://user-images.githubusercontent.com/11997060/91301467-5b7af580-e77b-11ea-99d5-70e51edd6e2c.png)
That is because normalize-url version 4 throw error on this method, they fixed in the newer version.

Thanks a lot!