### PR TITLE
Fix normalized url internal error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,11 @@ export default class MagicUrl {
   }
   normalize (url) {
     if (this.options.normalizeRegularExpression.test(url)) {
-      return normalizeUrl(url, this.options.normalizeUrlOptions)
+      try {
+        return normalizeUrl(url, this.options.normalizeUrlOptions)
+      } catch (error) {
+        console.error(error)
+      }
     }
     return url
   }


### PR DESCRIPTION
Hello there, 

I was notified that is not possible to update normalizedurl on this Pull request: https://github.com/visualjerk/quill-magic-url/pull/26

So, I just put the normalizedUrl function execution inside a try catch statement.

Thanks a lot!