### PR TITLE
Retain link text instead of overwriting to retain other attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,7 @@ export default class MagicUrl {
   textToUrl (index, url) {
     const ops = new Delta()
       .retain(index)
-      .delete(url.length)
-      .insert(url, {link: this.normalize(url)})
+      .retain(url.length, {link: this.normalize(url)})
     this.quill.updateContents(ops)
   }
   normalize (url) {


### PR DESCRIPTION
Currently working on a derivate of this and using https://github.com/markdown-it/linkify-it under the hood, where I noticed that the link does not retain other quill attributes.

`Delta.retain()` allows to set additional attributes without affecting others, so I use this instead of `.delete().insert()`
