### PR TITLE
chore: handle exception for SSR that window is undfined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,6 @@ export default class MagicUrl {
   }
 }
 
-if (window.Quill) {
+if (typeof window !== 'undefined' && window.Quill) {
   window.Quill.register('modules/magicUrl', MagicUrl);
 }


### PR DESCRIPTION
it causes error when SSR because there is no window object

related #42 

